### PR TITLE
Add support for note_tweet to handle long tweets

### DIFF
--- a/fields/tweet_fields.go
+++ b/fields/tweet_fields.go
@@ -23,6 +23,7 @@ const (
 	TweetFieldSource             TweetField = "source"
 	TweetFieldText               TweetField = "text"
 	TweetFieldWithheld           TweetField = "withheld"
+	TweetFieldNoteTweet          TweetField = "note_tweet"
 )
 
 func (f TweetField) String() string {

--- a/resources/tweet.go
+++ b/resources/tweet.go
@@ -24,6 +24,7 @@ type Tweet struct {
 	ReplySettings       *string             `json:"reply_settings,omitempty"`
 	Source              *string             `json:"source,omitempty"`
 	Withheld            *TweetWithheld      `json:"withheld,omitempty"`
+	NoteTweet           *TweetNoteTweet     `json:"note_tweet,omitempty"`
 }
 
 type TweetAttachments struct {
@@ -131,4 +132,14 @@ type ReferencedTweet struct {
 type TweetWithheld struct {
 	Copyright    *bool     `json:"copyright"`
 	CountryCodes []*string `json:"country_codes"`
+}
+
+type TweetNoteTweet struct {
+	Entities struct {
+		CashTags []TweetEntityTag `json:"cashtags"`
+		HashTags []TweetEntityTag `json:"hashtags"`
+		Mentions []TweetEntityTag `json:"mentions"`
+		URLs     []URL            `json:"urls"`
+	} `json:"entities"`
+	Text *string `json:"text"`
 }


### PR DESCRIPTION
This pull request addresses the issue of handling long tweets (over 280 characters) by leveraging Twitter's note_tweet field.